### PR TITLE
Upgrade Netty to 4.1.52 and Netty tcnative to 2.0.34.Final 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -270,7 +270,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-plugin</artifactId>
-          <version>2.22.2</version>
+          <version>3.0.0-M5</version>
           <configuration>
             <forkCount>${forkCounts}</forkCount>
             <trimStackTrace>false</trimStackTrace>
@@ -1249,12 +1249,12 @@
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-all</artifactId>
-        <version>4.1.48.Final</version>
+        <version>4.1.52.Final</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-tcnative-boringssl-static</artifactId>
-        <version>2.0.30.Final</version>
+        <version>2.0.34.Final</version>
         <scope>test</scope>
       </dependency>
 


### PR DESCRIPTION
- Update Netty to 4.1.52 and Netty tcnative to 2.0.34.Final which includes both security fixes and AArch64 performance improvements
- Refer release notes for detail:
  - https://netty.io/news/2020/05/13/4-1-50-Final.html
  - https://netty.io/news/2020/09/08/4-1-52-Final.html
- Upgraded surefire to 3.0.0-M5 due to compatibility